### PR TITLE
Capture 'taps' as points

### DIFF
--- a/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
+++ b/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
@@ -10,6 +10,7 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Color;
 import android.graphics.Path;
+import android.graphics.PathMeasure;
 import android.graphics.PointF;
 import android.graphics.Bitmap;
 import android.util.Log;
@@ -172,11 +173,20 @@ public class SketchCanvas extends View {
             paint.setStyle(Paint.Style.STROKE);
 
             if (path.path != null) {
-                canvas.drawPath(path.path, paint);    
+
+                // draw initial dot
+                PointF origin = path.points.get(0);
+                canvas.drawPoint(origin.x, origin.y, paint);
+
+                // draw path
+                canvas.drawPath(path.path, paint);
             } else {
                 Path canvasPath = new Path();
                 for(PointF p: path.points) {
-                    if (canvasPath.isEmpty()) canvasPath.moveTo(p.x, p.y);
+                    if (canvasPath.isEmpty()) {
+                      canvas.drawPoint(p.x, p.y, paint);
+                      canvasPath.moveTo(p.x, p.y);
+                    }
                     else canvasPath.lineTo(p.x, p.y);
                 }
 

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvasDelegate.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvasDelegate.m
@@ -15,16 +15,23 @@
         RNSketchData *data = _paths[index];
         bool first = true;
         CGContextSetLineWidth(context, (float)data.strokeWidth / 2.0);
+        CGContextSetLineCap(context, kCGLineCapRound);
         CGContextSetStrokeColorWithColor(context, [data.strokeColor CGColor]);
         
         if (data.cgPoints) {
-            CGContextAddLines(context, data.cgPoints, data.pointCount);
+            if (data.pointCount > 1) {
+                CGContextAddLines(context, data.cgPoints, data.pointCount);
+            } else if (data.pointCount == 1) {
+                CGPoint p = data.cgPoints[0];
+                CGContextMoveToPoint(context, p.x, p.y);
+                CGContextAddLineToPoint(context, p.x, p.y);
+            }
         } else {
             for (int i=0; i<_currentPoints.count; i++) {
                 CGPoint point = [_currentPoints[i] CGPointValue];
                 if (first)  CGContextMoveToPoint(context, point.x, point.y);
-                else  CGContextAddLineToPoint(context, point.x, point.y);
                 first = false;
+                CGContextAddLineToPoint(context, point.x, point.y);
             }
         }
         

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -132,8 +132,8 @@ class SketchCanvas extends React.Component {
   componentWillMount() {
     this.panResponder = PanResponder.create({
       // Ask to be the responder:
-      onStartShouldSetPanResponder: (evt, gestureState) => false,
-      onStartShouldSetPanResponderCapture: (evt, gestureState) => false,
+      onStartShouldSetPanResponder: (evt, gestureState) => true,
+      onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
       onMoveShouldSetPanResponder: (evt, gestureState) => true,
       onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
 
@@ -149,19 +149,19 @@ class SketchCanvas extends React.Component {
         if (Platform.OS === 'ios') {
           SketchCanvasManager.newPath(this._path.id, this._path.color, this._path.width)
           SketchCanvasManager.addPoint(
-            parseFloat((gestureState.moveX - this._offset.x).toFixed(2) * this._screenScale), 
-            parseFloat((gestureState.moveY - this._offset.y).toFixed(2) * this._screenScale)
+            parseFloat((gestureState.x0 - this._offset.x).toFixed(2) * this._screenScale),
+            parseFloat((gestureState.y0 - this._offset.y).toFixed(2) * this._screenScale)
           )
         } else {
           UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.newPath, [
             this._path.id, this._path.color, this._path.width,
           ])
           UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.addPoint, [
-            parseFloat((gestureState.moveX - this._offset.x).toFixed(2) * this._screenScale), 
-            parseFloat((gestureState.moveY - this._offset.y).toFixed(2) * this._screenScale)
+            parseFloat((gestureState.x0 - this._offset.x).toFixed(2) * this._screenScale),
+            parseFloat((gestureState.y0 - this._offset.y).toFixed(2) * this._screenScale)
           ])
         }
-        this._path.data.push(`${parseFloat(gestureState.moveX - this._offset.x).toFixed(2)},${parseFloat(gestureState.moveY - this._offset.y).toFixed(2)}`)
+        this._path.data.push(`${parseFloat(gestureState.x0 - this._offset.x).toFixed(2)},${parseFloat(gestureState.y0 - this._offset.y).toFixed(2)}`)
         this.props.onStrokeStart()
       },
       onPanResponderMove: (evt, gestureState) => {


### PR DESCRIPTION
This PR captures all touches at JS level (including 'pan start'), and renders them natively.

fixes #5
fixes #6