### PR TITLE
Update to modern `buildToolsVersion` on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "25.0.0"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
This adds support for e.g. Gradle 2.3.3, which has been required by some external React Native ecosystem packages.

Fixes #11 