### PR TITLE
Add `onPathsChange ` callback when the path count changes

### DIFF
--- a/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
+++ b/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
@@ -38,7 +38,7 @@ public class SketchCanvas extends View {
     public void clear() {
         this._paths.clear();
         this._currentPath = null;
-        invalidate();
+        invalidateCanvas();
     }
 
     public void newPath(int id, String strokeColor, int strokeWidth) {
@@ -48,7 +48,7 @@ public class SketchCanvas extends View {
 
     public void addPoint(float x, float y) {
         this._currentPath.addPoint(new PointF(x, y));
-        invalidate();
+        invalidateCanvas();
     }
 
     public void addPath(int id, String strokeColor, int strokeWidth, ArrayList<PointF> points) {
@@ -62,8 +62,8 @@ public class SketchCanvas extends View {
 
         if (!exist) {
             this._paths.add(new SketchData(id, strokeColor, strokeWidth, points));
-            invalidate();
-        } 
+            invalidateCanvas();
+        }
     }
 
     public void deletePath(int id) {
@@ -77,7 +77,7 @@ public class SketchCanvas extends View {
 
         if (index > -1) {
             this._paths.remove(index);
-            invalidate();
+            invalidateCanvas();
         }
     }
 
@@ -162,6 +162,16 @@ public class SketchCanvas extends View {
     protected void onDraw(Canvas canvas) {  
         super.onDraw(canvas);
         this.drawPath(canvas);
+    }
+
+    private void invalidateCanvas() {
+      WritableMap event = Arguments.createMap();
+      event.putInt("pathsUpdate", this._paths.size());
+      mContext.getJSModule(RCTEventEmitter.class).receiveEvent(
+          getId(),
+          "topChange",
+          event);
+      invalidate();
     }
 
     private void drawPath(Canvas canvas) {

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
@@ -155,6 +155,11 @@
 
 - (void) invalidate {
     dispatch_async(dispatch_get_main_queue(), ^{
+        
+        [_eventDispatcher sendInputEventWithName:@"topChange"
+                                            body: @{ @"target": self.reactTag,
+                                                     @"pathsUpdate": @(_paths.count) }];
+        
         delegate.currentPoints = _currentPoints;
         delegate.paths = _paths;
         [_layer setNeedsDisplay];

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -27,6 +27,7 @@ class SketchCanvas extends React.Component {
     style: View.propTypes.style,
     strokeColor: PropTypes.string,
     strokeWidth: PropTypes.number,
+    onPathsChange: PropTypes.func,
     onStrokeStart: PropTypes.func,
     onStrokeChanged: PropTypes.func,
     onStrokeEnd: PropTypes.func,
@@ -41,6 +42,7 @@ class SketchCanvas extends React.Component {
     style: null,
     strokeColor: '#000000',
     strokeWidth: 3,
+    onPathsChange: () => {},
     onStrokeStart: () => {},
     onStrokeChanged: () => {},
     onStrokeEnd: () => {},
@@ -215,7 +217,9 @@ class SketchCanvas extends React.Component {
         }}
         {...this.panResponder.panHandlers} 
         onChange={(e) => {
-          if (e.nativeEvent.hasOwnProperty('success')) {
+          if (e.nativeEvent.hasOwnProperty('pathsUpdate')) {
+            this.props.onPathsChange(e.nativeEvent.pathsUpdate)
+          } else if (e.nativeEvent.hasOwnProperty('success')) {
             this.props.onSketchSaved(e.nativeEvent.success)
           } else if (e.nativeEvent.hasOwnProperty('base64')) {
             this.props.onBase64(e.nativeEvent.base64)


### PR DESCRIPTION
Informs listeners when the path count changes - helpful for related UI controls, e.g. warning on destructive actions after the player has made strokes, or keying off of other events when the canvas is clear/wiped

Fixes #16 