### PR TITLE
fix `View.propTypes.style` crash on modern React Native

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,14 @@ import ReactNative, {
   Text,
   TouchableOpacity,
   FlatList,
+  ViewPropTypes,
 } from 'react-native'
 import SketchCanvas from './src/SketchCanvas'
 
 export default class extends React.Component {
   static propTypes = {
-    containerStyle: View.propTypes.style,
-    canvasStyle: View.propTypes.style,
+    containerStyle: ViewPropTypes.style,
+    canvasStyle: ViewPropTypes.style,
     onStrokeStart: PropTypes.func,
     onStrokeChanged: PropTypes.func,
     onStrokeEnd: PropTypes.func,

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -11,7 +11,8 @@ import ReactNative, {
   TouchableOpacity,
   PanResponder,
   Dimensions,
-  Platform
+  Platform,
+  ViewPropTypes,
 } from 'react-native'
 
 const RNSketchCanvas = requireNativeComponent('RNSketchCanvas', SketchCanvas, {
@@ -24,7 +25,7 @@ const SketchCanvasManager = NativeModules.RNSketchCanvasManager || {};
 
 class SketchCanvas extends React.Component {
   static propTypes = {
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     strokeColor: PropTypes.string,
     strokeWidth: PropTypes.number,
     onStrokeStart: PropTypes.func,


### PR DESCRIPTION
(I believe `view.propTypes` was deprecated in like RN 0.45)

fixes #20 