### PR TITLE
Match on-screen size React Native JS pixels to `strokeWidth` on Android

### DIFF
--- a/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
+++ b/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
@@ -24,14 +24,14 @@ import java.util.ArrayList;
 
 import javax.annotation.Nullable;
 
-public class SketchCanvas extends View {  
-  
+public class SketchCanvas extends View {
+
     private ArrayList<SketchData> _paths = new ArrayList<SketchData>();
     private SketchData _currentPath = null;
 
     private ThemedReactContext mContext;
-    
-    public SketchCanvas(ThemedReactContext context) {  
+
+    public SketchCanvas(ThemedReactContext context) {
         super(context);
         mContext = context;
     }
@@ -42,7 +42,7 @@ public class SketchCanvas extends View {
         invalidateCanvas(true);
     }
 
-    public void newPath(int id, int strokeColor, int strokeWidth) {
+    public void newPath(int id, int strokeColor, float strokeWidth) {
         this._currentPath = new SketchData(id, strokeColor, strokeWidth);
         this._paths.add(this._currentPath);
         invalidateCanvas(true);
@@ -53,7 +53,7 @@ public class SketchCanvas extends View {
         invalidateCanvas(false);
     }
 
-    public void addPath(int id, int strokeColor, int strokeWidth, ArrayList<PointF> points) {
+    public void addPath(int id, int strokeColor, float strokeWidth, ArrayList<PointF> points) {
         boolean exist = false;
         for(SketchData data: this._paths) {
             if (data.id == id) {
@@ -106,18 +106,18 @@ public class SketchCanvas extends View {
             }
             this.drawPath(canvas);
 
-            File file = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES) + 
+            File file = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES) +
                 File.separator + folder + File.separator + filename + (format.equals("png") ? ".png" : ".jpg"));
             try {
                 bitmap.compress(
-                    format.equals("png") ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG, 
-                    format.equals("png") ? 100 : 90, 
+                    format.equals("png") ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG,
+                    format.equals("png") ? 100 : 90,
                     new FileOutputStream(file));
                 this.onSaved(true);
             } catch (Exception e) {
                 e.printStackTrace();
                 this.onSaved(false);
-            }   
+            }
         } else {
             Log.e("SketchCanvas", "Failed to create folder!");
             this.onSaved(false);
@@ -140,17 +140,17 @@ public class SketchCanvas extends View {
             canvas.drawARGB(255, 255, 255, 255);
         }
         this.drawPath(canvas);
- 
+
         ByteArrayOutputStream byteArrayOS = new ByteArrayOutputStream();
         bitmap.compress(
-            format.equals("png") ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG, 
-            format.equals("png") ? 100 : 90, 
+            format.equals("png") ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG,
+            format.equals("png") ? 100 : 90,
             byteArrayOS);
         return Base64.encodeToString(byteArrayOS.toByteArray(), Base64.DEFAULT);
     }
 
-    @Override  
-    protected void onDraw(Canvas canvas) {  
+    @Override
+    protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
         this.drawPath(canvas);
     }
@@ -170,7 +170,7 @@ public class SketchCanvas extends View {
     private void drawPath(Canvas canvas) {
         for(SketchData path: this._paths) {
             Paint paint = new Paint();
-            paint.setColor(path.strokeColor); 
+            paint.setColor(path.strokeColor);
             paint.setStrokeWidth(path.strokeWidth);
             paint.setStyle(Paint.Style.STROKE);
             paint.setStrokeCap(Paint.Cap.ROUND);
@@ -201,4 +201,4 @@ public class SketchCanvas extends View {
             }
         }
     }
-}  
+}

--- a/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvasManager.java
+++ b/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvasManager.java
@@ -52,7 +52,7 @@ public class SketchCanvasManager extends SimpleViewManager<SketchCanvas> {
     @Override
     public Map<String,Integer> getCommandsMap() {
         Map<String, Integer> map = new HashMap<>();
-        
+
         map.put("addPoint", COMMAND_ADD_POINT);
         map.put("newPath", COMMAND_NEW_PATH);
         map.put("clear", COMMAND_CLEAR);
@@ -66,7 +66,7 @@ public class SketchCanvasManager extends SimpleViewManager<SketchCanvas> {
 
     @Override
     protected void addEventEmitters(ThemedReactContext reactContext, SketchCanvas view) {
-        
+
     }
 
     @Override
@@ -77,7 +77,7 @@ public class SketchCanvasManager extends SimpleViewManager<SketchCanvas> {
                 return;
             }
             case COMMAND_NEW_PATH: {
-                view.newPath(args.getInt(0), args.getInt(1), args.getInt(2));
+                view.newPath(args.getInt(0), args.getInt(1), (float)args.getDouble(2));
                 return;
             }
             case COMMAND_CLEAR: {
@@ -91,7 +91,7 @@ public class SketchCanvasManager extends SimpleViewManager<SketchCanvas> {
                     String[] coor = path.getString(i).split(",");
                     pointPath.add(new PointF(Float.parseFloat(coor[0]), Float.parseFloat(coor[1])));
                 }
-                view.addPath(args.getInt(0), args.getInt(1), args.getInt(2), pointPath);
+                view.addPath(args.getInt(0), args.getInt(1), (float)args.getDouble(2), pointPath);
                 return;
             }
             case COMMAND_DELETE_PATH: {

--- a/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchData.java
+++ b/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchData.java
@@ -8,16 +8,17 @@ import java.util.ArrayList;
 
 public class SketchData {
     public ArrayList<PointF> points = new ArrayList<PointF>();
-    public int id, strokeColor, strokeWidth;
+    public int id, strokeColor;
+    public float strokeWidth;
     public Path path;
 
-    public SketchData(int id, int strokeColor, int strokeWidth) {
+    public SketchData(int id, int strokeColor, float strokeWidth) {
         this.id = id;
         this.strokeColor = strokeColor;
         this.strokeWidth = strokeWidth;
     }
 
-    public SketchData(int id, int strokeColor, int strokeWidth, ArrayList<PointF> points) {
+    public SketchData(int id, int strokeColor, float strokeWidth, ArrayList<PointF> points) {
         this.id = id;
         this.strokeColor = strokeColor;
         this.strokeWidth = strokeWidth;


### PR DESCRIPTION
Fixes #24 

This is important for cases where e.g. you are displaying stroke size on screen. Prior to this fix, high DPI Android phones will display smaller strokes vs. the size provided by the React Native code layer.

(Note: There was also some linting that my editor, Atom/Nuclide, seems to have applied automatically. Probably a tabs vs. spaces thing.)