### PR TITLE
Update SketchCanvas.js

### DIFF
--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -205,8 +205,8 @@ class SketchCanvas extends React.Component {
       onPanResponderRelease: (evt, gestureState) => {
         if (!this.props.touchEnabled) return
         if (this._path) {
-          this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user })
           this._paths.push({ path: this._path, size: this._size, drawer: this.props.user })
+          this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user })
         }
         UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.endPath, [])
       },


### PR DESCRIPTION
change `onPanResponderRelease` => first update `this._paths` then call `onStrokeEnd`.
use case: if calling the method `getPaths` from within `onStrokeEnd` the method will return `this._paths` before it has been updated => resulting in stale data.

Excellent repo! Thanks!