### PR TITLE
Avoid multiple touch event when drawing

### DIFF
--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -162,6 +162,7 @@ class SketchCanvas extends React.Component {
 
       onPanResponderGrant: (evt, gestureState) => {
         if (!this.props.touchEnabled) return
+        if (gestureState.numberActiveTouches > 1) return
         const e = evt.nativeEvent
         this._offset = { x: e.pageX - e.locationX, y: e.pageY - e.locationY }
         this._path = {

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -211,6 +211,15 @@ class SketchCanvas extends React.Component {
         }
         UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.endPath, [])
       },
+      onPanResponderTerminate: (evt, gestureState) => {
+        // Another component has become the responder, so this gesture should be cancelled
+        if (!this.props.touchEnabled) return;
+        if (this._path) {
+          this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user });
+          this._paths.push({ path: this._path, size: this._size, drawer: this.props.user });
+        }
+        UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.endPath, []);
+      },
 
       onShouldBlockNativeResponder: (evt, gestureState) => {
         return true;


### PR DESCRIPTION
Drawing will behave wrongly when put two fingers simultaneously on the canvas.
It will call `onStrokeStart()` event and draw a dot on canvas, without the `onStrokeEnd()` event.
Since the multiple touch make no sense for drawing, I dismiss the gesture with multiple touches.

There are two different flows for gesture:
1. Normal flow: `onPanResponderGrant -> onPanResponderMove -> onPanResponderEnd`
2. Terminate flow: `onPanResponderGrant -> onPanResponderMove -> onPanResponderTerminate`

The terminate flow will happen when user put one finger to draw, and put the second finger before leave the first one.
That way it will not call `onStrokeEnd`, and leave that stroke as an orphan.

I handle it in the callback `onPanResponderTerminate`, and do the same thing as `onPanResponderRelease` did.