### PR TITLE
Fix memory leak on iOS

### DIFF
--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
@@ -39,6 +39,13 @@
     return self;
 }
 
+- (void)dealloc {
+    CGContextRelease(_drawingContext);
+    _drawingContext = nil;
+    CGImageRelease(_frozenImage);
+    _frozenImage = nil;
+}
+
 - (void)drawRect:(CGRect)rect {
     CGContextRef context = UIGraphicsGetCurrentContext();
 


### PR DESCRIPTION
Hi again ;)

I'm fixing the memory leak I introduced when I worked on the performance issue.

On the app I'm working on (https://itunes.apple.com/us/app/caribu/id763451959?mt=8) I use a lot of canvas (allocated for the current page of the book you're reading) and the memory was growing wild when turning pages.
This fixes it all. Memory now stays constant while turning pages.

Hope it will help someone else.

Cheers,