### PR TITLE
Fix: `onPathsChange()` callback no longer fires on iOS after update to 0.7.0

### DIFF
--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
@@ -246,7 +246,6 @@
         [data drawInContext:_drawingContext];
         [self setFrozenImageNeedsUpdate];
         [self setNeedsDisplay];
-        [self notifyPathsUpdate];
     }
 }
 
@@ -287,6 +286,7 @@
         [_currentPath drawInContext:_drawingContext];
     }
     _currentPath = nil;
+    [self notifyPathsUpdate];
 }
 
 - (void) clear {

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
@@ -438,11 +438,9 @@
 }
 
 - (void)notifyPathsUpdate {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (_onChange) {
-            _onChange(@{ @"pathsUpdate": @(_paths.count) });
-        }
-    });
+    if (_onChange) {
+        _onChange(@{ @"pathsUpdate": @(_paths.count) });
+    }
 }
 
 @end

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
@@ -438,9 +438,11 @@
 }
 
 - (void)notifyPathsUpdate {
-    if (_onChange) {
-        _onChange(@{ @"pathsUpdate": @(_paths.count) });
-    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (_onChange) {
+            _onChange(@{ @"pathsUpdate": @(_paths.count) });
+        }
+    });
 }
 
 @end


### PR DESCRIPTION
Fixes #95

I have found the source of the problem; `addPath()` and more specifically the `onLayout()` callback in the render function of `SketchCanvas.js` is no longer triggered except at launch, where no paths exist. This is probably due to some of the optimizations done in 0.7.0, but I actually couldn't deduce the exact cause--the rendering code on iOS has grown outside of my expertise!

The result is that `addPath:strokeColor:strokeWidth:points:` is no longer being called. As a workaround (but also maybe a better fix), I have added a call to the `onPathsChange()` event when `endPath()` is triggered.

Additional suggestion @terrylinla - we should probably pull out the entire `addPath:strokeColor:strokeWidth:points:` function, as well as its up & downstream stuff. I just didn't want to do this because I am a little out of date on the repo in general.