### PR TITLE
add `promptForExternalWritePermissions` bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ AppRegistry.registerComponent('example', () => example);
 | user | `string` | An identifier to identify who draws the path. Useful when undo between two users |
 | touchEnabled | `bool` | If false, disable touching. Default is true.  |
 | localSourceImage | `object` | Require an object (see [below](#objects)) which consists of `filename`, `directory`(optional) and `mode`(optional). If set, the image will be loaded and display as a background in canvas. (Thanks to diego-caceres-galvan))([Here](#background-image) for details) |
+| promptForExternalWritePermissions | `bool` | If true, prompt the user for write permissions to an External Storage device. Default is false. |
 | permissionDialogTitle | `string` | Android Only: Provide a Dialog Title for the Image Saving PermissionDialog. Defaults to empty string if not set |
 | permissionDialogMessage | `string` | Android Only: Provide a Dialog Message for the Image Saving PermissionDialog. Defaults to empty string if not set |
 

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ export default class RNSketchCanvas extends React.Component {
     maxStrokeWidth: PropTypes.number,
     strokeWidthStep: PropTypes.number,
 
+    promptForExternalWritePermissions: PropTypes.bool,
     savePreference: PropTypes.func,
     onSketchSaved: PropTypes.func,
 
@@ -195,10 +196,12 @@ export default class RNSketchCanvas extends React.Component {
   }
 
   async componentDidMount() {
-    const isStoragePermissionAuthorized = await requestPermissions(
-      this.props.permissionDialogTitle,
-      this.props.permissionDialogMessage,
-    );
+    if (this.props.promptForExternalWritePermissions) {
+      const isStoragePermissionAuthorized = await requestPermissions(
+        this.props.permissionDialogTitle,
+        this.props.permissionDialogMessage,
+      );
+    }
   }
 
   render() {

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -50,6 +50,7 @@ class SketchCanvas extends React.Component {
     })),
     localSourceImage: PropTypes.shape({ filename: PropTypes.string, directory: PropTypes.string, mode: PropTypes.oneOf(['AspectFill', 'AspectFit', 'ScaleToFill']) }),
 
+    promptForExternalWritePermissions: PropTypes.bool,
     permissionDialogTitle: PropTypes.string,
     permissionDialogMessage: PropTypes.string,
   };
@@ -218,10 +219,12 @@ class SketchCanvas extends React.Component {
   }
 
   async componentDidMount() {
-    const isStoragePermissionAuthorized = await requestPermissions(
-      this.props.permissionDialogTitle,
-      this.props.permissionDialogMessage,
-    );
+    if (this.props.promptForExternalWritePermissions) {
+      const isStoragePermissionAuthorized = await requestPermissions(
+        this.props.permissionDialogTitle,
+        this.props.permissionDialogMessage,
+      );
+    }
   }
 
   render() {


### PR DESCRIPTION
Related to #100. This is not the best fix, as it does not fix item (2) in the issue noted, but at least it removes the permission prompt for (most?) consumers who don't need it.

A more proper fix, per #100, would prompt not based on a `bool` but actually based on some parameter specifying where one would like to save (and determining that the user doesn't have rights to it). Also, this prompt should appear only after `save()` (or similar) is invoked--not before.