### PR TITLE
Adjust line stroke width based on canvas size

### DIFF
--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.h
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.h
@@ -10,8 +10,8 @@
 
 - (BOOL)openSketchFile:(NSString *)filename directory:(NSString*) directory contentMode:(NSString*)mode;
 - (void)setCanvasText:(NSArray *)text;
-- (void)newPath:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(int) strokeWidth;
-- (void)addPath:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(int) strokeWidth points:(NSArray*) points;
+- (void)newPath:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(CGFloat) strokeWidth;
+- (void)addPath:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(CGFloat) strokeWidth points:(NSArray*) points;
 - (void)deletePath:(int) pathId;
 - (void)addPointX: (float)x Y: (float)y;
 - (void)endPath;

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
@@ -220,7 +220,7 @@
     [self setNeedsDisplay];
 }
 
-- (void)newPath:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(int) strokeWidth {
+- (void)newPath:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(CGFloat) strokeWidth {
     _currentPath = [[RNSketchData alloc]
                     initWithId: pathId
                     strokeColor: strokeColor
@@ -228,7 +228,7 @@
     [_paths addObject: _currentPath];
 }
 
-- (void) addPath:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(int) strokeWidth points:(NSArray*) points {
+- (void) addPath:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(CGFloat) strokeWidth points:(NSArray*) points {
     bool exist = false;
     for(int i=0; i<_paths.count; i++) {
         if (((RNSketchData*)_paths[i]).pathId == pathId) {

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvasManager.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvasManager.m
@@ -72,7 +72,7 @@ RCT_EXPORT_METHOD(addPoint:(nonnull NSNumber *)reactTag x: (float)x y: (float)y)
     }];
 }
 
-RCT_EXPORT_METHOD(addPath:(nonnull NSNumber *)reactTag pathId: (int) pathId strokeColor: (UIColor*) strokeColor strokeWidth: (int) strokeWidth points: (NSArray*) points)
+RCT_EXPORT_METHOD(addPath:(nonnull NSNumber *)reactTag pathId: (int) pathId strokeColor: (UIColor*) strokeColor strokeWidth: (CGFloat) strokeWidth points: (NSArray*) points)
 {
     NSMutableArray *cgPoints = [[NSMutableArray alloc] initWithCapacity: points.count];
     for (NSString *coor in points) {
@@ -85,7 +85,7 @@ RCT_EXPORT_METHOD(addPath:(nonnull NSNumber *)reactTag pathId: (int) pathId stro
     }];
 }
 
-RCT_EXPORT_METHOD(newPath:(nonnull NSNumber *)reactTag pathId: (int) pathId strokeColor: (UIColor*) strokeColor strokeWidth: (int) strokeWidth)
+RCT_EXPORT_METHOD(newPath:(nonnull NSNumber *)reactTag pathId: (int) pathId strokeColor: (UIColor*) strokeColor strokeWidth: (CGFloat) strokeWidth)
 {
     [self runCanvas:reactTag block:^(RNSketchCanvas *canvas) {
         [canvas newPath: pathId strokeColor: strokeColor strokeWidth: strokeWidth];

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchData.h
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchData.h
@@ -17,8 +17,8 @@
 @property (nonatomic, readonly) NSArray<NSValue*> *points;
 @property (nonatomic, readonly) BOOL isTranslucent;
 
-- (instancetype)initWithId:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(int) strokeWidth points: (NSArray*) points;
-- (instancetype)initWithId:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(int) strokeWidth;
+- (instancetype)initWithId:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(CGFloat) strokeWidth points: (NSArray*) points;
+- (instancetype)initWithId:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(CGFloat) strokeWidth;
 
 - (CGRect)addPoint:(CGPoint) point;
 

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchData.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchData.m
@@ -24,7 +24,7 @@
     UIBezierPath *_path;
 }
 
-- (instancetype)initWithId:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(int) strokeWidth {
+- (instancetype)initWithId:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(CGFloat) strokeWidth {
     self = [super init];
     if (self) {
         _pathId = pathId;
@@ -39,7 +39,7 @@
     return self;
 }
 
-- (instancetype)initWithId:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(int) strokeWidth points: (NSArray*) points {
+- (instancetype)initWithId:(int) pathId strokeColor:(UIColor*) strokeColor strokeWidth:(CGFloat) strokeWidth points: (NSArray*) points {
     self = [super init];
     if (self) {
         _pathId = pathId;

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -119,12 +119,15 @@ class SketchCanvas extends React.Component {
   addPath(data) {
     if (this._initialized) {
       if (this._paths.filter(p => p.path.id === data.path.id).length === 0) this._paths.push(data)
+      const screenWidthAdjustment = (this._size.width / data.size.width) * this._screenScale;
+      const screenHeightAdjustment = (this._size.height / data.size.height) * this._screenScale;
+      const screenAverageAdjustment = (screenWidthAdjustment + screenHeightAdjustment) / 2.0;
       const pathData = data.path.data.map(p => {
         const coor = p.split(',').map(pp => parseFloat(pp).toFixed(2))
-        return `${coor[0] * this._screenScale * this._size.width / data.size.width},${coor[1] * this._screenScale * this._size.height / data.size.height}`;
+        return `${coor[0] * screenWidthAdjustment},${coor[1] * screenHeightAdjustment}`;
       })
       UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.addPath, [
-        data.path.id, processColor(data.path.color), data.path.width * this._screenScale, pathData
+        data.path.id, processColor(data.path.color), data.path.width * screenAverageAdjustment, pathData
       ])
     } else {
       this._pathsToProcess.filter(p => p.path.id === data.path.id).length === 0 && this._pathsToProcess.push(data)


### PR DESCRIPTION
In this case, takes an average of width and height. this will be exactly correct for two canvases that share the same aspect ratio, but only "close" to correct for other like highly divergent canvases.

Perhaps there is a better solution for non-square canvases? But I'm unsure what it would be.

Fixes #102 