### PR TITLE
Added getBase64 function to RNSKetchCanvas

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,10 @@ export default class RNSketchCanvas extends React.Component {
     this._alphaStep = -1
   }
 
+  getBase64(imageType, transparent, includeImage, includeText, cropToImageSize, callback) {
+      return this._sketchCanvas.getBase64(imageType, transparent, includeImage, includeText, cropToImageSize, callback)
+  }
+
   clear() {
     this._sketchCanvas.clear()
   }


### PR DESCRIPTION
SketchCanvas has a getBase64 function, however RNSketchCanvas doesn't. This is just a quick fix to add this feature to RNSketchCanvas.